### PR TITLE
Update link to documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Get this here alogside an introduction: https://aaronpeikert.github.io/StenoGrap
 
 # More Details!
 
-For a more detailed documentation of this package look here: https://structuralequationmodels.github.io/Taxonomy.jl/dev/
+For a more detailed documentation of this package look here: https://formal-methods-mpi.github.io/Taxonomy.jl


### PR DESCRIPTION
The link to the documentation was outdated. Quick pull request in case it was wanted like this because the package isn't finished?